### PR TITLE
CAPI-185: make 'cardHolder' property required in CardData

### DIFF
--- a/spec/definitions/CardData.yaml
+++ b/spec/definitions/CardData.yaml
@@ -5,6 +5,7 @@ allOf:
     description: Банковская карта
     required:
       - cardNumber
+      - cardHolder
       - expDate
       - cvv
     properties:


### PR DESCRIPTION
to match thrift spec
https://github.com/rbkmoney/damsel/blob/3954a8daa621c3c5e1069f06da2ce3f641db893d/proto/cds.thrift#L25