### PR TITLE
CAPI-270: add token provider to PaymentToolDetails

### DIFF
--- a/spec/definitions/BankCardDetails.yaml
+++ b/spec/definitions/BankCardDetails.yaml
@@ -17,3 +17,6 @@ properties:
   paymentSystem:
     x-rebillyMerge:
       - $ref: '#/definitions/BankCardPaymentSystem'
+  tokenProvider:
+    x-rebillyMerge:
+      - $ref: '#/definitions/BankCardTokenProvider'


### PR DESCRIPTION
!!! Внимание !!! 
Т.к. в `PayoutToolDetailsBankCard` (метод **getPayoutTools**) используются те же структуры, то там соответственно тоже появляется токен-провайдер. Вроде как не мешает, т.к. он опционален.