### PR TITLE
CAPI-313: remove paymentSession as a required field of PaymentResource

### DIFF
--- a/spec/definitions/PaymentResource.yaml
+++ b/spec/definitions/PaymentResource.yaml
@@ -1,7 +1,6 @@
 type: object
 description: Данные одноразового платежного средства
 required:
-  - paymentSession
   - paymentToolToken
 properties:
   paymentToolToken:


### PR DESCRIPTION
Backport of #250