### PR TITLE
CAPI-323: Wallet payout tool type

### DIFF
--- a/spec/paths/analytics@shops@{shopID}@payouts.yaml
+++ b/spec/paths/analytics@shops@{shopID}@payouts.yaml
@@ -24,8 +24,8 @@ get:
       required: false
       type: string
       enum:
-        - PayoutCard
         - PayoutAccount
+        - Wallet
   responses:
     '200':
       description: Найденные выплаты


### PR DESCRIPTION
выпилил еще старый тип, который больше не поддерживается дамзелью