### PR TITLE
Negative fee in payout summary item

### DIFF
--- a/spec/definitions/PayoutSummaryItem.yaml
+++ b/spec/definitions/PayoutSummaryItem.yaml
@@ -21,7 +21,6 @@ properties:
     description: 'Общая комиссия по данному типу операций над денежными средствами в минорных денежных единицах'
     type: integer
     format: int64
-    minimum: 0
   currency:
     x-rebillyMerge:
       - $ref: '#/definitions/Currency'


### PR DESCRIPTION
Не так давно в процессинге ВНЕЗАПНО появилась новая проводка, которая описывает возврат комиссии за платеж в случае рефанда. Такая проводка описывалась, как отрицательная сумма в комиссии за рефанд, и считалась минусом к сумме рефанда. Но в описании выплаты появились отрицательные комиссии в рефандах, которые допустимы, но не на сваге.

PS
Когда нибудь этот payout summary item должен выпилиться к херам, я считаю.