### PR TITLE
fix validUntil leak

### DIFF
--- a/spec/definitions/PaymentResource.yaml
+++ b/spec/definitions/PaymentResource.yaml
@@ -18,8 +18,3 @@ properties:
     allOf:
       - $ref: '#/definitions/ClientInfo'
       - readOnly: true
-  validUntil:
-    description: Дата и время, до наступления которых платежный токен остается действительным
-    type: string
-    format: date-time
-    readOnly: true

--- a/spec/definitions/PaymentResourceResult.yaml
+++ b/spec/definitions/PaymentResourceResult.yaml
@@ -1,0 +1,11 @@
+type: object
+allOf:
+  - $ref: '#/definitions/PaymentResource'
+  - type: object
+    properties:
+      validUntil:
+        description: Дата и время, до наступления которых токен платежного средства остается действительным
+        type: string
+        format: date-time
+        readOnly: true
+

--- a/spec/paths/processing@payment-resources.yaml
+++ b/spec/paths/processing@payment-resources.yaml
@@ -20,7 +20,7 @@ post:
     '201':
       description: Токен и сессия созданы
       schema:
-        $ref: '#/definitions/PaymentResource'
+        $ref: '#/definitions/PaymentResourceResult'
     '401':
       $ref: '#/responses/Unauthorized'
     '400':


### PR DESCRIPTION
Описание параметра validUntil  метода createPaymentResource протекало в схемы других метдов возвращающих PaymentResource, например createBinding
устранено созданием отдельной схемы на ответ createPaymentResource(PaymentResourceResult)