### PR TITLE
CAPI-433 Allow empty string in last4 field

### DIFF
--- a/spec/definitions/BankCardDetails.yaml
+++ b/spec/definitions/BankCardDetails.yaml
@@ -5,7 +5,7 @@ properties:
   cardNumberMask:
     description: Маскированый номер карты
     type: string
-    pattern: '^\d{0,6}\*+\d{0,2,4}$'
+    pattern: '^\d{0,6}\*+\d{0,4}$'
   first6:
     description: |
       Первые цифры номера карты.
@@ -16,7 +16,7 @@ properties:
   last4:
     description: Последние цифры номера карты
     type: string
-    pattern: '^\d{0,2,4}$'
+    pattern: '^\d{0,4}$'
   paymentSystem:
     x-rebillyMerge:
       - $ref: '#/definitions/BankCardPaymentSystem'

--- a/spec/paths/analytics@shops@{shopID}@invoices.yaml
+++ b/spec/paths/analytics@shops@{shopID}@invoices.yaml
@@ -122,7 +122,7 @@ get:
       description: Последние цифры номера карты
       required: false
       type: string
-      pattern: '^\d{0,2,4}$'
+      pattern: '^\d{0,4}$'
     - name: rrn
       in: query
       description: 'Retrieval Reference Number'

--- a/spec/paths/analytics@shops@{shopID}@payments.yaml
+++ b/spec/paths/analytics@shops@{shopID}@payments.yaml
@@ -102,7 +102,7 @@ get:
       description: Последние цифры номера карты
       required: false
       type: string
-      pattern: '^\d{0,2,4}$'
+      pattern: '^\d{0,4}$'
     - name: rrn
       in: query
       description: 'Retrieval Reference Number'


### PR DESCRIPTION
Sometimes, at processing tokenized cards, it may be that we don't know the last digits of the card number.