### PR TITLE
CAPI-433 Allow empty string in last4 field in v1

### DIFF
--- a/spec/definitions/BankCardDetails.yaml
+++ b/spec/definitions/BankCardDetails.yaml
@@ -5,7 +5,7 @@ properties:
   cardNumberMask:
     description: Маскированый номер карты
     type: string
-    pattern: '^\d{6,8}\*+\d{2,4}$'
+    pattern: '^\d{6,8}\*+\d{0,4}$'
   bin:
     description: BIN банка-эмитента карты
     type: string
@@ -13,7 +13,7 @@ properties:
   lastDigits:
     description: Последние цифры номера карты
     type: string
-    pattern: '^\d{2,4}$'
+    pattern: '^\d{0,4}$'
   paymentSystem:
     x-rebillyMerge:
       - $ref: '#/definitions/BankCardPaymentSystem'

--- a/spec/paths/analytics@shops@{shopID}@invoices.yaml
+++ b/spec/paths/analytics@shops@{shopID}@invoices.yaml
@@ -117,7 +117,7 @@ get:
       description: Маскированый номер карты
       required: false
       type: string
-      pattern: '^\d{2,4}$'
+      pattern: '^\d{0,4}$'
     - name: paymentAmount
       in: query
       description: Сумма платежа

--- a/spec/paths/analytics@shops@{shopID}@payments.yaml
+++ b/spec/paths/analytics@shops@{shopID}@payments.yaml
@@ -107,7 +107,7 @@ get:
       description: Маскированый номер карты
       required: false
       type: string
-      pattern: '^\d{2,4}$'
+      pattern: '^\d{0,4}$'
     - name: paymentAmount
       in: query
       description: Сумма платежа


### PR DESCRIPTION
Sometimes, at processing tokenized cards, it may be that we don't know the last digits of the card number.