### PR TITLE
ED-123: +gateawayMerchantID +RealmMode

### DIFF
--- a/spec/definitions/BankCard.yaml
+++ b/spec/definitions/BankCard.yaml
@@ -17,3 +17,6 @@ allOf:
         items:
           x-rebillyMerge:
             - $ref: '#/definitions/BankCardTokenProvider'
+      tokenProviderData:
+        allOf:
+          - $ref: '#/definitions/BankCardTokenProviderData'

--- a/spec/definitions/BankCardTokenProviderData.yaml
+++ b/spec/definitions/BankCardTokenProviderData.yaml
@@ -1,0 +1,35 @@
+type: object
+description: |
+  Данные для интеграции с провайдерами платежных токенов.
+  Эти параметры заданы в нашей системе и могут быть использованы для построении запросов к провайдеру токенов
+  или корректного отображения платежной формы.
+  Для более подробной информации ознакомьтесь с нашими руководствами по интеграции:
+    * [GooglePay](https://developer.rbk.money/docs/payments/googlepay),
+    * [ApplePay](https://developer.rbk.money/docs/payments/applepay).
+required:
+  - merchantID
+  - realm
+properties:
+  merchantID:
+    description: |
+      Идентификатор мерчанта в платёжной организации.
+      Может быть использован для передачи провайдеру платежных токенов. Например, ожидается,
+      что этот параметр передается как gatewayMerchantID для GooglePay и/или YandexPay,
+      а затем используется для привязки токена к указанному магазину.
+    type: string
+  merchantName:
+    description: |
+      Имя мерчанта в платежной организации.
+      Может быть использовано, например,  как `merchantInfo.merchantName` в GooglePay
+      или `merchant.name` в YandexPay или `displayName` в ApplePay.
+    type: string
+  orderID:
+    description: |
+      Идентификатор оплачиваемого счета в платёжной организации.
+      Может быть использован, например,  как `orderNumber`  в SamsungPay или `order.id` в YandexPay.
+      Использование системного идентифкатора может оказаться полезным при отладке или сверке данных
+      с данными провайдера.
+    type: string
+  realm:
+    x-rebillyMerge:
+      - $ref: '#/definitions/RealmMode'

--- a/spec/definitions/PaymentInstitution.yaml
+++ b/spec/definitions/PaymentInstitution.yaml
@@ -21,7 +21,5 @@ properties:
       x-rebillyMerge:
         - $ref: '#/definitions/Residence'
   realm:
-    type: string
-    enum:
-      - test
-      - live
+    x-rebillyMerge:
+      - $ref: '#/definitions/RealmMode'

--- a/spec/definitions/RealmMode.yaml
+++ b/spec/definitions/RealmMode.yaml
@@ -1,0 +1,5 @@
+description: Режим рабочего окружения платежной организации
+type: string
+enum:
+  - test
+  - live

--- a/spec/paths/processing@payment-institutions.yaml
+++ b/spec/paths/processing@payment-institutions.yaml
@@ -7,13 +7,11 @@ get:
     - $ref: '#/parameters/requestID'
     - $ref: '#/parameters/deadline'
     - $ref: '#/parameters/residence'
-    - name: realm
-      in: query
-      required: false
-      type: string
-      enum:
-        - test
-        - live
+    - x-rebillyMerge:
+      - name: realm
+        in: query
+        required: false
+      - $ref: '#/definitions/RealmMode'
   responses:
     '200':
       description: List of payment institutions


### PR DESCRIPTION
Для `getInvoicePaymentMethods|getInvoicePaymentMethodsByTemplateID` при наличии способа оплаты BankCard и доступных провайдеров платежных токенов, помещаются атрибуты `gateawayMerchantID` и `realm` 

1) В атрибуте gateawayMerchantID содержится закодированный в base64 map вида:

```
#{
 version: 1
 shop
 realm
}
```

где

`shop`: _InvoiceID -> getInvoiceByID -> shopID_
`realm`: _getShopByID -> contractID -> getContractByID -> paymentInstitutionID -> getPaymentInstitutionByRef -> realm_ 


?? не понятно когда мы хотим привязывать к мерчанту, когда к конкретному магазину, когда к конкретному счету - поэтому пока оставляю только магазин. PartyID есть в контексте. 

Сомнения вызваны формулировкой _убедиться, что прилетевший токен действительно предназначается для оплаты именно этого инвойса или в этом магазине_ (https://rbkmoney.atlassian.net/browse/ED-124) - которая предполагает возможность выбора. 

Не уверен, нужен ли здесь `realm`, выглядит так, что этот флаг требуется только форме. сами мы можем его воспроизвести из shopID . 

`version`  нужен  если оставлять сложную структуру 

2) В атрибут  realm дублируется значение gateawayMerchantID.realm из описанной выше структуры для удобства доступа на стороне клиента


***) можно рассмотреть упрощенную реализацию одного атрибута gateawayMerchantID вида `<shop-id>/<realm>`**   


Далее  `gateawayMerchantID` приходит в вызове  `createPaymentResource` где мы производим его сверку на стороне провайдера на основе [Unwrap](https://github.com/rbkmoney/damsel/blob/master/proto/payment_tool_provider.thrift#L125), а затем распаковываем структуру из п1  и сохраняем привязку с [shop_id](https://github.com/rbkmoney/damsel/blob/ed-124/ft/token_binding/proto/payment_tool_token.thrift#L16)  в нашем токене https://github.com/rbkmoney/damsel/pull/670  

При оплате с помощью нашего платежного токена будем проверять данные привязки.



